### PR TITLE
[SC-26] Fix service action configurations

### DIFF
--- a/sc-actions-provider/app.py
+++ b/sc-actions-provider/app.py
@@ -44,7 +44,7 @@ def create_provider(aws_account_id, name, ssm_doc_name, ssm_doc_version, assume_
                 "Name": ssm_doc_name,
                 "Version": ssm_doc_version,
                 "AssumeRole": assume_role,
-                "Parameters": "[{\"Name\":\"AutomationAssumeRole\",\"Type\":\"TARGET\"}]"
+                "Parameters": "[{\"Name\":\"InstanceId\",\"Type\":\"TARGET\"}]"
               }
     )
     id = response['ServiceActionDetail']['ServiceActionSummary']['Id']


### PR DESCRIPTION
The SC service action configuration that works:

Parameter name = InstanceId
Permissions -> AssumeRole = arn:aws:iam::XXXXXXXXX:role/SCEC2LaunchRole