### PR TITLE
[SC-26] Reduce custom resource permissions

### DIFF
--- a/sc-actions-provider/app.py
+++ b/sc-actions-provider/app.py
@@ -21,21 +21,6 @@ def get_parameters(event):
     assume_role = event['ResourceProperties']['AssumeRole']
     return aws_account_id, name, ssm_doc_name, ssm_doc_version, assume_role
 
-def validate_parameters(aws_account_id, name, ssm_doc_name, ssm_doc_version, assume_role):
-    logger.debug("Validate SSM doc " + ssm_doc_name + ", " + ssm_doc_version)
-    ssm = boto3.client("ssm")
-    ssm.get_document(
-        Name=ssm_doc_name,
-        DocumentVersion=ssm_doc_version,
-    )
-
-    assume_role_name = assume_role.split(':')[5].split('/')[1]
-    logger.debug("Validate role: " + assume_role_name)
-    iam = boto3.client("iam")
-    iam.get_role(
-        RoleName=assume_role_name
-    )
-
 def create_provider(aws_account_id, name, ssm_doc_name, ssm_doc_version, assume_role):
     response = sc.create_service_action(
         Name=name,
@@ -54,7 +39,6 @@ def create_provider(aws_account_id, name, ssm_doc_name, ssm_doc_version, assume_
 @helper.create
 def create(event, context):
     logger.debug("Received event: " + json.dumps(event, sort_keys=False))
-    validate_parameters(*get_parameters(event))
     return create_provider(*get_parameters(event))
 
 @helper.delete

--- a/template.yaml
+++ b/template.yaml
@@ -33,8 +33,6 @@ Resources:
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         - "arn:aws:iam::aws:policy/AWSServiceCatalogAdminFullAccess"
-        - "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
-        - "arn:aws:iam::aws:policy/IAMFullAccess"
 Outputs:
   CreateFunctionArn:
     Value: !GetAtt CreateFunction.Arn


### PR DESCRIPTION
Let crhelper handle errors on action creation, update and
delete so we can reduce the policy scope for this custom
resource.