### PR TITLE
Revert "Update should return the same resource ID (#8)"

### DIFF
--- a/sc-actions-provider/app.py
+++ b/sc-actions-provider/app.py
@@ -56,6 +56,7 @@ def update(event, context):
     logger.debug("Received event: " + json.dumps(event, sort_keys=False))
     new_properties = event['ResourceProperties']
     old_properties = event['OldResourceProperties']
+    id = event['PhysicalResourceId']
     if new_properties != old_properties:
         response = sc.update_service_action(
             Id=id,
@@ -68,7 +69,9 @@ def update(event, context):
                     "Parameters": "[{\"Name\":\"AutomationAssumeRole\",\"Type\":\"TARGET\"}]"
                   }
         )
-    return event['PhysicalResourceId']
+        id = response['ServiceActionDetail']['ServiceActionSummary']['Id']
+        logger.info("updated sc action = " + id)
+    return id
 
 def lambda_handler(event, context):
     helper(event, context)


### PR DESCRIPTION
This reverts commit 3a4bdba7933acc1a5b3ab41e3c9bc7e2d2262f82.

I believe this commit is wrong.

The cloudformation workflow on an update is
1. create new resource if necessary
2. delete previously provisioned resource

With that workflow it makes sense to return a new ID instead
of returning the same ID.  So the workflow would be..
1. create new resource if necessary with new ID
2. return new ID
3. delete previously provisioned resource (using old ID)
now CFN can reference the updated resource with new ID